### PR TITLE
fix: pyproject.toml loading of package files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,12 @@ zip-safe  = false
 include-package-data = true
 packages = ["pyesef"]
 
+[tool.setuptools.packages.find]
+include = ["pyesef", "pyesef.*"]
+exclude = ["script", "tests"]
+
 [tool.setuptools.package-data]
-"pyesef" = ["py.typed"]
+"pyesef" = ["py.typed", "static/statement_definition.json"]
 
 [tool.black]
 target-version = ["py311"]


### PR DESCRIPTION
issue: build was not bundling the expected files together, causing imports to break
fix:

- update search path for packages
- explictly bundle static json

in the future, it may be worth using `tox` in order to test the packages separately